### PR TITLE
feat: Specifying CSV Format Files

### DIFF
--- a/src/ControlFileBuilder.php
+++ b/src/ControlFileBuilder.php
@@ -11,9 +11,7 @@ use Stringable;
 
 class ControlFileBuilder implements Stringable
 {
-    public function __construct(public SQLLoader $loader)
-    {
-    }
+    public function __construct(public SQLLoader $loader) {}
 
     public function __toString(): string
     {

--- a/src/CsvFile.php
+++ b/src/CsvFile.php
@@ -11,9 +11,7 @@ final class CsvFile
     /**
      * @param  resource  $stream
      */
-    private function __construct(public string $file, public $stream)
-    {
-    }
+    private function __construct(public string $file, public $stream) {}
 
     /**
      * A list of possible modes. The default is 'w' (open for writing).:

--- a/src/InputFile.php
+++ b/src/InputFile.php
@@ -14,8 +14,7 @@ class InputFile implements Stringable
         public ?string $discardFile = null,
         public ?string $discardMax = null,
         public ?string $osFileProcClause = null,
-    ) {
-    }
+    ) {}
 
     public function __toString(): string
     {

--- a/src/SQLLoader.php
+++ b/src/SQLLoader.php
@@ -70,7 +70,7 @@ class SQLLoader
         array $formatOptions = [],
         ?string $when = null,
         bool $csv = false,
-        bool $withEmbedded = false,
+        bool $withEmbedded = true,
     ): static {
         if (! $columns && $this->defaultColumns) {
             $columns = $this->createColumnsFromHeaders($table, $this->defaultColumns);

--- a/src/SQLLoader.php
+++ b/src/SQLLoader.php
@@ -46,9 +46,7 @@ class SQLLoader
 
     protected string $dateFormat = 'YYYY-MM-DD"T"HH24:MI:SS."000000Z"';
 
-    public function __construct(public array $options = [])
-    {
-    }
+    public function __construct(public array $options = []) {}
 
     /**
      * Define mode to use.
@@ -71,6 +69,8 @@ class SQLLoader
         bool $trailing = true,
         array $formatOptions = [],
         ?string $when = null,
+        bool $csv = false,
+        bool $withEmbedded = false,
     ): static {
         if (! $columns && $this->defaultColumns) {
             $columns = $this->createColumnsFromHeaders($table, $this->defaultColumns);
@@ -88,7 +88,7 @@ class SQLLoader
         $columns = array_merge($columns, $this->constants);
 
         $this->tables[] = new TableDefinition(
-            $table, $columns, $terminatedBy, $enclosedBy, $trailing, $formatOptions, $when
+            $table, $columns, $terminatedBy, $enclosedBy, $trailing, $formatOptions, $when, $csv, $withEmbedded
         );
 
         return $this;

--- a/src/TableDefinition.php
+++ b/src/TableDefinition.php
@@ -17,7 +17,7 @@ class TableDefinition implements Stringable
         public array $formatOptions = [],
         public ?string $when = null,
         public bool $csv = false,
-        public bool $withEmbedded = false,
+        public bool $withEmbedded = true,
     ) {}
 
     public function __toString(): string

--- a/src/TableDefinition.php
+++ b/src/TableDefinition.php
@@ -16,8 +16,9 @@ class TableDefinition implements Stringable
         public bool $trailing = false,
         public array $formatOptions = [],
         public ?string $when = null,
-    ) {
-    }
+        public bool $csv = false,
+        public bool $withEmbedded = false,
+    ) {}
 
     public function __toString(): string
     {
@@ -27,12 +28,21 @@ class TableDefinition implements Stringable
             $sql .= "WHEN {$this->when}".PHP_EOL;
         }
 
+        if ($this->csv) {
+            $sql .= 'FIELDS CSV '.($this->withEmbedded ? 'WITH' : 'WITHOUT').' EMBEDDED';
+        }
+
         if ($this->terminatedBy) {
-            $sql .= "FIELDS TERMINATED BY '{$this->terminatedBy}' ";
+            $sql .= ! str_contains($sql, 'FIELDS') ? 'FIELDS ' : ' ';
+            $sql .= "TERMINATED BY '{$this->terminatedBy}' ";
         }
 
         if ($this->enclosedBy) {
-            $sql .= "OPTIONALLY ENCLOSED BY '{$this->enclosedBy}'".PHP_EOL;
+            $sql .= "OPTIONALLY ENCLOSED BY '{$this->enclosedBy}'";
+        }
+
+        if ($this->csv || $this->terminatedBy || $this->enclosedBy) {
+            $sql .= PHP_EOL;
         }
 
         if ($this->formatOptions) {

--- a/src/TableDefinition.php
+++ b/src/TableDefinition.php
@@ -28,22 +28,7 @@ class TableDefinition implements Stringable
             $sql .= "WHEN {$this->when}".PHP_EOL;
         }
 
-        if ($this->csv) {
-            $sql .= 'FIELDS CSV '.($this->withEmbedded ? 'WITH' : 'WITHOUT').' EMBEDDED';
-        }
-
-        if ($this->terminatedBy) {
-            $sql .= ! str_contains($sql, 'FIELDS') ? 'FIELDS ' : ' ';
-            $sql .= "TERMINATED BY '{$this->terminatedBy}' ";
-        }
-
-        if ($this->enclosedBy) {
-            $sql .= "OPTIONALLY ENCLOSED BY '{$this->enclosedBy}'";
-        }
-
-        if ($this->csv || $this->terminatedBy || $this->enclosedBy) {
-            $sql .= PHP_EOL;
-        }
+        $sql .= $this->delimiterSpecification();
 
         if ($this->formatOptions) {
             $sql .= implode(PHP_EOL, $this->formatOptions).PHP_EOL;
@@ -63,5 +48,29 @@ class TableDefinition implements Stringable
         $sql .= ')'.PHP_EOL;
 
         return $sql;
+    }
+
+    private function delimiterSpecification(): string
+    {
+        $specs = ['FIELDS'];
+
+        if ($this->csv) {
+            $specs[] = 'CSV';
+            $specs[] = $this->withEmbedded ? 'WITH EMBEDDED' : 'WITHOUT EMBEDDED';
+        }
+
+        if ($this->terminatedBy) {
+            $specs[] = "TERMINATED BY '{$this->terminatedBy}'";
+        }
+
+        if ($this->enclosedBy) {
+            $specs[] = "OPTIONALLY ENCLOSED BY '{$this->enclosedBy}'";
+        }
+
+        if (count($specs) > 1) {
+            return implode(' ', $specs).PHP_EOL;
+        }
+
+        return '';
     }
 }

--- a/tests/Unit/TableDefinitionTest.php
+++ b/tests/Unit/TableDefinitionTest.php
@@ -109,21 +109,21 @@ test('it can build with csv format', function () {
     );
 
     assertEquals(
-        "INTO TABLE users\nFIELDS CSV WITHOUT EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
-        $table
+        "INTO TABLE users\nFIELDS CSV WITH EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
+        $table->__toString()
     );
 });
 
-test('it can build with csv format with embedded', function () {
+test('it can build with csv format without embedded', function () {
     $table = new TableDefinition(
         'users',
         ['id', 'name', 'email'],
         csv: true,
-        withEmbedded: true,
+        withEmbedded: false,
     );
 
     assertEquals(
-        "INTO TABLE users\nFIELDS CSV WITH EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
+        "INTO TABLE users\nFIELDS CSV WITHOUT EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
         $table
     );
 });

--- a/tests/Unit/TableDefinitionTest.php
+++ b/tests/Unit/TableDefinitionTest.php
@@ -59,8 +59,8 @@ test('it can build it\'s own sql string without enclosed by', function () {
     );
 
     assertEquals(
-        "INTO TABLE users\nFIELDS TERMINATED BY ',' \n(\n  id,\n  name,\n  email\n)\n",
-        $table,
+        "INTO TABLE users\nFIELDS TERMINATED BY ','\n(\n  id,\n  name,\n  email\n)\n",
+        $table
     );
 });
 

--- a/tests/Unit/TableDefinitionTest.php
+++ b/tests/Unit/TableDefinitionTest.php
@@ -59,8 +59,8 @@ test('it can build it\'s own sql string without enclosed by', function () {
     );
 
     assertEquals(
-        "INTO TABLE users\nFIELDS TERMINATED BY ',' (\n  id,\n  name,\n  email\n)\n",
-        $table
+        "INTO TABLE users\nFIELDS TERMINATED BY ',' \n(\n  id,\n  name,\n  email\n)\n",
+        $table,
     );
 });
 
@@ -97,6 +97,33 @@ test('it can build with when clause', function () {
 
     assertEquals(
         "INTO TABLE users\nWHEN id > 0\n(\n  id,\n  name,\n  email\n)\n",
+        $table
+    );
+});
+
+test('it can build with csv format', function () {
+    $table = new TableDefinition(
+        'users',
+        ['id', 'name', 'email'],
+        csv: true,
+    );
+
+    assertEquals(
+        "INTO TABLE users\nFIELDS CSV WITHOUT EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
+        $table
+    );
+});
+
+test('it can build with csv format with embedded', function () {
+    $table = new TableDefinition(
+        'users',
+        ['id', 'name', 'email'],
+        csv: true,
+        withEmbedded: true,
+    );
+
+    assertEquals(
+        "INTO TABLE users\nFIELDS CSV WITH EMBEDDED\n(\n  id,\n  name,\n  email\n)\n",
         $table
     );
 });


### PR DESCRIPTION
Allow usage of CSV clause to instruct sql loader to read specified files as comma-separated-values.

This PR proposes its usage via into() method of SQLLoader class.